### PR TITLE
Bug fix between pawns and kings

### DIFF
--- a/JS/script.js
+++ b/JS/script.js
@@ -160,6 +160,22 @@ class Piece{
                     if(p.name == 'Knight'){
                         Piece.N(p).filter(square => os.push(square))
                     }
+                    if(p.name == 'Pawn'){
+                        for(let r=0; r<os.length; r++){
+                            if(os[r].slice(0,1) == p.pos.slice(0,1)){
+                                os.splice(r,1)
+                                r-=1
+                            }
+                        }
+                        for(let r=0; r<2; r++){
+                            const index = chessBoard.letters.findIndex(letter => letter == p.pos.slice(0,1))
+                            const colors = ['white','black']
+                            const pos = chessBoard.letters[index+1-r*2]+JSON.stringify(JSON.parse(p.pos.slice(1,2))+1-(2*colors.findIndex(c => c == p.color)))
+                            if(chessBoard.squares.find(sq => sq == pos)){
+                                os.push(pos)
+                            }
+                        }
+                    }
                     for(let r=0; r<os.length; r++){
                         if(os[r] == s){
                             openSquares.splice(i,1)


### PR DESCRIPTION
With the checking system it checked all available squares that pieces could move(of opposite color to king) and kings(of opposite color to pieces) could not move into those squares. The exception with this was pawns because pawns can move forward but cannot take other pieces the same way. they can only take diagonally if a piece of opposite color is there.